### PR TITLE
Updates callbacks to std::function allowing c++ classes method binding

### DIFF
--- a/mdns.cpp
+++ b/mdns.cpp
@@ -16,12 +16,12 @@ void PrintHex(const unsigned char data) {
   Serial.print(" ");
 }
 
+void MDns::begin(){
+  Serial.println("Initializing Multicast.");
+  Udp.beginMulticast(WiFi.localIP(), IPAddress(224, 0, 0, 251), MDNS_TARGET_PORT);
+}
+
 bool MDns::loop() {
-  if (!init) {
-    init = true;
-    Serial.println("Initializing Multicast.");
-    Udp.beginMulticast(WiFi.localIP(), IPAddress(224, 0, 0, 251), MDNS_TARGET_PORT);
-  }
   data_size = Udp.parsePacket();
   if ( data_size > 12) {
     if(data_size > largest_packet_seen){

--- a/mdns.cpp
+++ b/mdns.cpp
@@ -38,7 +38,6 @@ bool MDns::loop() {
     // We've received a packet which is long enough to contain useful data so
     // read the data from it.
     Udp.read(data_buffer, data_size); // read the packet into the buffer
-
     // data_buffer[0] and data_buffer[1] contain the Query ID field which is unused in mDNS.
 
     // data_buffer[2] and data_buffer[3] are DNS flags which are mostly unused in mDNS.
@@ -511,6 +510,10 @@ void MDns::PopulateAnswerResult(Answer* answer) {
       break;
   }
 }
+
+MDns::~MDns(){
+  Udp.stop();
+};
 
 bool writeToBuffer(const byte value, char* p_name_buffer, int* p_name_buffer_pos,
                    const int name_buffer_len) {

--- a/mdns.cpp
+++ b/mdns.cpp
@@ -16,7 +16,7 @@ void PrintHex(const unsigned char data) {
   Serial.print(" ");
 }
 
-void MDns::begin(){
+void MDns::startUdpMulticast(){
   Serial.println("Initializing Multicast.");
   Udp.beginMulticast(WiFi.localIP(), IPAddress(224, 0, 0, 251), MDNS_TARGET_PORT);
 }

--- a/mdns.h
+++ b/mdns.h
@@ -64,6 +64,9 @@ typedef struct Answer{
 class MDns {
  private:
  public:
+  // Whether UDP socket has not yet been initialised. 
+  bool init = false;
+  
   // Simple constructor does not fire any callbacks on incoming data.
   // Default incoming data_buffer size is used.
   MDns() : MDns(NULL, NULL, NULL, MAX_PACKET_SIZE) {}
@@ -78,9 +81,9 @@ class MDns {
   //   p_packet_function : Callback fires for every mDNS packet that arrives.
   //   p_query_function : Callback fires for every mDNS Query that arrives as part of a packet.
   //   p_answer_function : Callback fires for every mDNS Answer that arrives as part of a packet.
-  MDns(void (*p_packet_function)(const MDns*), 
-       void (*p_query_function)(const Query*), 
-       void (*p_answer_function)(const Answer*)) :
+  MDns(std::function<void(const MDns*)> p_packet_function, 
+       std::function<void(const Query*)> p_query_function, 
+       std::function<void(const Answer*)> p_answer_function) :
     MDns(p_packet_function, p_query_function, p_answer_function, MAX_PACKET_SIZE) { }
 
   // Constructor takes callbacks which fire when mDNS data arrives.
@@ -89,9 +92,9 @@ class MDns {
   //   p_query_function : Callback fires for every mDNS Query that arrives as part of a packet.
   //   p_answer_function : Callback fires for every mDNS Answer that arrives as part of a packet.
   //   max_packet_size_ : Set the data_buffer size allocated to store incoming packets.
-  MDns(void (*p_packet_function)(const MDns*), 
-       void (*p_query_function)(const Query*), 
-       void (*p_answer_function)(const Answer*),
+  MDns(std::function<void(const MDns*)> p_packet_function, 
+       std::function<void(const Query*)> p_query_function, 
+       std::function<void(const Answer*)> p_answer_function,
        int max_packet_size_) :
 #ifdef DEBUG_STATISTICS
        buffer_size_fail(0),
@@ -113,9 +116,9 @@ class MDns {
   //   p_query_function : Callback fires for every mDNS Query that arrives as part of a packet.
   //   p_answer_function : Callback fires for every mDNS Answer that arrives as part of a packet.
   //   max_packet_size_ : Set the data_buffer size allocated to store incoming packets.
-  MDns(void (*p_packet_function)(const MDns*), 
-       void (*p_query_function)(const Query*), 
-       void (*p_answer_function)(const Answer*),
+  MDns(std::function<void(const MDns*)> p_packet_function, 
+       std::function<void(const Query*)> p_query_function,
+       std::function<void(const Answer*)> p_answer_function,
        byte* data_buffer_,
        int max_packet_size_) :
 #ifdef DEBUG_STATISTICS
@@ -175,18 +178,15 @@ class MDns {
   void Parse_Answer(Answer& answer);
   unsigned int PopulateName(const char* name_buffer);
   void PopulateAnswerResult(Answer* answer);
-  
-  // Whether UDP socket has not yet been initialised. 
-  bool init;
 
   // Pointer to function that gets called for every incoming mDNS packet.
-  void (*p_packet_function_)(const MDns*);
+  std::function<void(const MDns*)> p_packet_function_;
 
   // Pointer to function that gets called for every incoming query.
-  void (*p_query_function_)(const Query*);
+  std::function<void(const Query*)> p_query_function_;
 
   // Pointer to function that gets called for every incoming answer.
-  void (*p_answer_function_)(const Answer*);
+  std::function<void(const Answer*)> p_answer_function_;
 
   // Position in data_buffer while processing packet.
   unsigned int buffer_pointer;

--- a/mdns.h
+++ b/mdns.h
@@ -104,7 +104,9 @@ class MDns {
        buffer_pointer(0),
        data_buffer(new byte[max_packet_size_]),
        max_packet_size(max_packet_size_)
-       { };
+       { 
+         this->startUdpMulticast();
+       };
 
   // Constructor can be passed the buffer to hold the mDNS data.
   // This way the potentially large buffer can be shared with other processes.
@@ -129,12 +131,11 @@ class MDns {
        buffer_pointer(0),
        data_buffer(data_buffer_),
        max_packet_size(max_packet_size_)
-       { };
+       { 
+         this->startUdpMulticast();
+       };
 
   ~MDns();
-
-  // Initializes multicast
-  void begin();
 
   // Call this regularly to check for an incoming packet.
   bool loop();
@@ -176,6 +177,9 @@ class MDns {
   unsigned int packet_count;
 #endif
  private:
+  // Initializes udp multicast
+  void startUdpMulticast();
+
   void Parse_Query(Query& query);
   void Parse_Answer(Answer& answer);
   unsigned int PopulateName(const char* name_buffer);

--- a/mdns.h
+++ b/mdns.h
@@ -64,9 +64,6 @@ typedef struct Answer{
 class MDns {
  private:
  public:
-  // Whether UDP socket has not yet been initialised. 
-  bool init = false;
-  
   // Simple constructor does not fire any callbacks on incoming data.
   // Default incoming data_buffer size is used.
   MDns() : MDns(NULL, NULL, NULL, MAX_PACKET_SIZE) {}
@@ -135,6 +132,9 @@ class MDns {
        { };
 
   ~MDns();
+
+  // Initializes multicast
+  void begin();
 
   // Call this regularly to check for an incoming packet.
   bool loop();

--- a/mdns.h
+++ b/mdns.h
@@ -134,6 +134,8 @@ class MDns {
        max_packet_size(max_packet_size_)
        { };
 
+  ~MDns();
+
   // Call this regularly to check for an incoming packet.
   bool loop();
   // Deprecated. Use loop() instead.


### PR DESCRIPTION
**Description:**
Using std::functions for the callbacks one can std::bind instance methods from c++ classes.
This change preserves previous function pointers functionality.

**Scenario:**
Class A triggers a mDNS query. Class A has a onMDNSAnswer() method that should be called after receiving a mDNS answer. Using std::bind, one can pass onMDNSAnswer() as an instance method callback to one of MDns constructores.

**Example:**

    // Constructor
    ClassA::ClassA(){
      mdnsClient = mdns::MDns(NULL, NULL, std::bind(&ClassA::onMDNSAnswer, this, std::placeholders::_1));
    }

    // Instance callback
    void ClassA::onMDNSAnswer(const mdns::Answer* answer){
    }