### PR TITLE
Fix for core 3.0.0+, buffer_pointer comparison fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ void setup() {
     }
   }
   Serial.println();
+
+  my_mdns.begin();
 }
 
 void loop() {

--- a/examples/mdns_test/mdns_test.ino
+++ b/examples/mdns_test/mdns_test.ino
@@ -165,6 +165,7 @@ void setup()
 
   Serial.println("Connected to wifi");
 
+  my_mdns.begin(); // call to startUdpMulticast
 
   // Query for all host information for a paticular service. ("_mqtt" in this case.)
   my_mdns.Clear();

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -46,6 +46,8 @@ void setup() {
   }
   printWifiStatus();
   Serial.println();
+
+  my_mdns.begin(); // call to startUdpMulticast
 }
 
 unsigned int last_packet_count = 0;

--- a/mdns.cpp
+++ b/mdns.cpp
@@ -23,6 +23,13 @@ void MDns::startUdpMulticast(){
   Udp.beginMulticast(WiFi.localIP(), IPAddress(224, 0, 0, 251), MDNS_TARGET_PORT);
 }
 
+void MDns::begin() {
+#ifdef DEBUG_OUTPUT
+Serial.println("Called begin");
+#endif
+  this->startUdpMulticast();
+}
+
 bool MDns::loop() {
   data_size = Udp.parsePacket();
   if ( data_size > 12) {
@@ -83,7 +90,7 @@ bool MDns::loop() {
           p_query_function_(&query);
         }
       }
-      if(buffer_pointer >= data_size){
+      if(buffer_pointer > data_size){
         return false;
       }
 #ifdef DEBUG_OUTPUT
@@ -100,7 +107,7 @@ bool MDns::loop() {
           p_answer_function_(&answer);
         }
       }
-      if(buffer_pointer >= data_size){
+      if(buffer_pointer > data_size){
         return false;
       }
 #ifdef DEBUG_OUTPUT
@@ -358,7 +365,7 @@ void MDns::Parse_Query(Query& query) {
     query.valid = false;
   }
 
-  if (buffer_pointer >= data_size) {
+  if (buffer_pointer > data_size) {
     // We've over-run the returned data.
     // Something has gone wrong receiving or parsing the data.
 #ifdef DEBUG_OUTPUT

--- a/mdns.h
+++ b/mdns.h
@@ -105,7 +105,6 @@ class MDns {
        data_buffer(new byte[max_packet_size_]),
        max_packet_size(max_packet_size_)
        { 
-         this->startUdpMulticast();
        };
 
   // Constructor can be passed the buffer to hold the mDNS data.
@@ -132,10 +131,12 @@ class MDns {
        data_buffer(data_buffer_),
        max_packet_size(max_packet_size_)
        { 
-         this->startUdpMulticast();
        };
 
   ~MDns();
+
+// added to call startUdpMulticast
+void begin();
 
   // Call this regularly to check for an incoming packet.
   bool loop();


### PR DESCRIPTION
1. Move call to startUdpMulticast from constructor to new begin() function
2. Change some instances of 'buffer_pointer >= data_size' to 'buffer_pointer > data_size'